### PR TITLE
ci: Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,14 +19,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v2.2.2
         with:
           version: 7.11.0
 
       - name: Setup Node.js with pnpm
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -64,6 +64,6 @@ jobs:
       - name: Discord notification
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@0.3.2
         with:
           args: "The project `{{ EVENT_PAYLOAD.repository.full_name }}` has been deployed."

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/conventional.yml
+++ b/.github/workflows/conventional.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: aslafy-z/conventional-pr-title-action@v2
+      - uses: aslafy-z/conventional-pr-title-action@v2.4.4
         with:
           success-state: Title follows the specification.
           failure-state: Title does not follow the specification.

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -18,14 +18,14 @@ jobs:
       actions: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v2.2.2
         with:
           version: 7.11.0
 
       - name: Setup Node.js with pnpm
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: "16.x"
           cache: "pnpm"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0) on 2022-10-04T09:40:24Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release [v3.5.0](https://github.com/actions/setup-node/releases/tag/v3.5.0) on 2022-09-27T13:40:45Z
* **[aslafy-z/conventional-pr-title-action](https://github.com/aslafy-z/conventional-pr-title-action)** published a new release [v2.4.4](https://github.com/aslafy-z/conventional-pr-title-action/releases/tag/v2.4.4) on 2022-08-23T12:38:04Z
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release [v2.2.2](https://github.com/pnpm/action-setup/releases/tag/v2.2.2) on 2022-05-28T14:27:55Z
* **[Ilshidur/action-discord](https://github.com/Ilshidur/action-discord)** published a new release [0.3.2](https://github.com/Ilshidur/action-discord/releases/tag/0.3.2) on 2021-06-20T15:18:26Z
