### PR TITLE
ci: Update GitHub Action Versions

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_SECRET }}
           ignore: '["actions/checkout@v2", "actions/cache@v2"]'
 
-      - uses: paulhatch/semantic-version@v4.0.2
+      - uses: paulhatch/semantic-version@v4.0.3
         with:
           tag_prefix: "v"
           major_pattern: "(MAJOR)"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[paulhatch/semantic-version](https://github.com/paulhatch/semantic-version)** published a new release [v4.0.3](https://github.com/PaulHatch/semantic-version/releases/tag/v4.0.3) on 2021-10-29T16:06:14Z
