### PR TITLE
ci: Update GitHub Action Versions

### DIFF
--- a/.github/workflows/conventional.yml
+++ b/.github/workflows/conventional.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: aslafy-z/conventional-pr-title-action@v2.4.4
+      - uses: aslafy-z/conventional-pr-title-action@v3.0.0
         with:
           success-state: Title follows the specification.
           failure-state: Title does not follow the specification.


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[aslafy-z/conventional-pr-title-action](https://github.com/aslafy-z/conventional-pr-title-action)** published a new release [v3.0.0](https://github.com/aslafy-z/conventional-pr-title-action/releases/tag/v3.0.0) on 2022-10-07T14:55:04Z
