### PR TITLE
chore: Update GitHub Action Versions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.1.0
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.2.3
         with:
           version: 7.11.0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.2.3
         with:
           version: 7.11.0
 
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.2.3
         with:
           version: 7.11.0
 
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2.2.3
         with:
           version: 7.11.0
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release [v2.2.3](https://github.com/pnpm/action-setup/releases/tag/v2.2.3) on 2022-10-11T05:06:36Z
