### PR TITLE
ci: Update GitHub Action Versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v2.5.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -19,14 +19,14 @@ jobs:
       actions: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v2.5.0
 
-      - uses: pnpm/action-setup@v2.2.3
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7.11.0
 
       - name: Setup Node.js with pnpm
-        uses: actions/setup-node@v3.5.0
+        uses: actions/setup-node@v3.5.1
         with:
           node-version: "16.x"
           cache: "pnpm"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,13 +18,13 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v2.5.0
 
-      - uses: pnpm/action-setup@v2.2.3
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7.11.0
 
-      - uses: actions/setup-node@v3.5.0
+      - uses: actions/setup-node@v3.5.1
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -42,13 +42,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v2.5.0
 
-      - uses: pnpm/action-setup@v2.2.3
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7.11.0
 
-      - uses: actions/setup-node@v3.5.0
+      - uses: actions/setup-node@v3.5.1
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -85,13 +85,13 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v2.5.0
 
-      - uses: pnpm/action-setup@v2.2.3
+      - uses: pnpm/action-setup@v2.2.4
         with:
           version: 7.11.0
 
-      - uses: actions/setup-node@v3.5.0
+      - uses: actions/setup-node@v3.5.1
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -103,7 +103,7 @@ jobs:
         run: pnpm run build --if-present
 
       - name: Netlify Actions
-        uses: nwtgck/actions-netlify@v1.2.3
+        uses: nwtgck/actions-netlify@v1.2.4
         with:
           publish-dir: "./build"
           production-branch: main


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release [v3.5.1](https://github.com/actions/setup-node/releases/tag/v3.5.1) on 2022-10-13T12:19:17Z
* **[nwtgck/actions-netlify](https://github.com/nwtgck/actions-netlify)** published a new release [v1.2.4](https://github.com/nwtgck/actions-netlify/releases/tag/v1.2.4) on 2022-10-14T22:10:48Z
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release [v2.2.4](https://github.com/pnpm/action-setup/releases/tag/v2.2.4) on 2022-10-15T18:14:46Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v2.5.0](https://github.com/actions/checkout/releases/tag/v2.5.0) on 2022-10-13T15:51:55Z
